### PR TITLE
Support for optional field values

### DIFF
--- a/modules/culturefeed_content/src/Plugin/Field/FieldFormatter/CultureFeedContentDefaultFormatter.php
+++ b/modules/culturefeed_content/src/Plugin/Field/FieldFormatter/CultureFeedContentDefaultFormatter.php
@@ -111,21 +111,25 @@ class CultureFeedContentDefaultFormatter extends FormatterBase implements Contai
 
     /** @var \Drupal\culturefeed_content\Plugin\Field\FieldType\CultureFeedContentFieldType $item */
     foreach ($items as $delta => $item) {
-      $elements[$delta] = [
-        '#lazy_builder' => [
-          'culturefeed_content.field_lazy_builder:buildCulturefeedContent', [
-            $item->get('title')->getValue() ?? '',
-            $item->get('query_string')->getValue() ?? '',
-            $this->getSetting('view_mode'),
-            $item->get('rows')->getValue(),
-            $item->get('sort')->getValue(),
-            $item->get('sort_direction')->getValue() ?? 'desc',
-            $item->get('show_more_link')->getValue() ?? TRUE,
-            $item->get('more_link')->getValue() ?? '',
+      $query_string = $item->get('query_string')->getValue();
+
+      if (!empty($query_string)) {
+        $elements[$delta] = [
+          '#lazy_builder' => [
+            'culturefeed_content.field_lazy_builder:buildCulturefeedContent', [
+              $item->get('title')->getValue() ?? '',
+              $item->get('query_string')->getValue() ?? '',
+              $this->getSetting('view_mode'),
+              $item->get('rows')->getValue(),
+              $item->get('sort')->getValue(),
+              $item->get('sort_direction')->getValue() ?? 'desc',
+              $item->get('show_more_link')->getValue() ?? TRUE,
+              $item->get('more_link')->getValue() ?? '',
+            ],
           ],
-        ],
-        '#create_placeholder' => TRUE,
-      ];
+          '#create_placeholder' => TRUE,
+        ];
+      }
     }
 
     return $elements;

--- a/modules/culturefeed_content/src/Plugin/Field/FieldFormatter/CultureFeedContentDefaultFormatter.php
+++ b/modules/culturefeed_content/src/Plugin/Field/FieldFormatter/CultureFeedContentDefaultFormatter.php
@@ -118,7 +118,7 @@ class CultureFeedContentDefaultFormatter extends FormatterBase implements Contai
           '#lazy_builder' => [
             'culturefeed_content.field_lazy_builder:buildCulturefeedContent', [
               $item->get('title')->getValue() ?? '',
-              $item->get('query_string')->getValue() ?? '',
+              $query_string,
               $this->getSetting('view_mode'),
               $item->get('rows')->getValue(),
               $item->get('sort')->getValue(),


### PR DESCRIPTION
This allows the culturefeed content field to be empty by only rendering it if a query is specified. Otherwise the formatter will always output events, even though the field wasn't filled in.