### PR TITLE
Add support for altering search api v3 queries before they are executed.

### DIFF
--- a/modules/culturefeed_search_api/culturefeed_search_api.api.php
+++ b/modules/culturefeed_search_api/culturefeed_search_api.api.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Describes hooks provided by the Culturefeed search API module.
+ */
+
+use CultuurNet\SearchV3\SearchQueryInterface;
+use CultuurNet\SearchV3\Parameter\AudienceType;
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Alter a Culturefeed search query before it is executed.
+ *
+ * @param \CultuurNet\SearchV3\SearchQueryInterface $searchQuery
+ *   The search query to alter.
+ * @param string $type
+ *   The type of query that is executed. Can be one of the following:
+ *   - events
+ *   - event
+ *   - places
+ *   - offers.
+ *
+ * @see \Drupal\culturefeed_search_api\DrupalCulturefeedSearchClient::searchEvents()
+ * @see \Drupal\culturefeed_search_api\DrupalCulturefeedSearchClient::searchEvent()
+ * @see \Drupal\culturefeed_search_api\DrupalCulturefeedSearchClient::searchPlaces()
+ * @see \Drupal\culturefeed_search_api\DrupalCulturefeedSearchClient::searchOffers()
+ */
+function hook_culturefeed_search_api_query_alter(SearchQueryInterface $searchQuery, $type = 'events') {
+  if ($type == 'events') {
+    $searchQuery->addParameter(new AudienceType('*'));
+  }
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/culturefeed_search_api/src/DrupalCulturefeedSearchClient.php
+++ b/modules/culturefeed_search_api/src/DrupalCulturefeedSearchClient.php
@@ -140,6 +140,7 @@ class DrupalCulturefeedSearchClient implements DrupalCulturefeedSearchClientInte
    * {@inheritdoc}
    */
   public function searchEvents(SearchQueryInterface $searchQuery) {
+    $this->alterQuery($searchQuery, 'events');
     $query = $searchQuery->toArray();
     $hash = Crypt::hashBase64(serialize($query));
     $cid = 'culturefeed_search_api.search_events:' . $hash;
@@ -181,6 +182,8 @@ class DrupalCulturefeedSearchClient implements DrupalCulturefeedSearchClientInte
     $searchQuery->addParameter(new Id($eventId));
     $searchQuery->addParameter(new AudienceType('*'));
 
+    $this->alterQuery($searchQuery, 'event');
+
     $events = $this->client->searchEvents($searchQuery);
     $items = $events->getMember()->getItems() ?? [];
 
@@ -201,6 +204,7 @@ class DrupalCulturefeedSearchClient implements DrupalCulturefeedSearchClientInte
    * {@inheritdoc}
    */
   public function searchPlaces(SearchQueryInterface $searchQuery) {
+    $this->alterQuery($searchQuery, 'places');
     return $this->client->searchPlaces($searchQuery);
   }
 
@@ -208,6 +212,7 @@ class DrupalCulturefeedSearchClient implements DrupalCulturefeedSearchClientInte
    * {@inheritdoc}
    */
   public function searchOffers(SearchQueryInterface $searchQuery) {
+    $this->alterQuery($searchQuery, 'offers');
     return $this->client->searchOffers($searchQuery);
   }
 
@@ -243,6 +248,22 @@ class DrupalCulturefeedSearchClient implements DrupalCulturefeedSearchClientInte
     }
 
     return $this->staticCache[$cid];
+  }
+
+  /**
+   * Alter a Culturefeed search query before it is executed.
+   *
+   * @param \CultuurNet\SearchV3\SearchQueryInterface $searchQuery
+   *   The search query to alter.
+   * @param string $type
+   *   The type of query that is executed. Can be one of the following:
+   *   - events
+   *   - event
+   *   - places
+   *   - offers.
+   */
+  protected function alterQuery(SearchQueryInterface $searchQuery, $type = 'events') {
+    \Drupal::moduleHandler()->alter('culturefeed_search_api_query', $searchQuery, $type);
   }
 
 }


### PR DESCRIPTION
This introduces a hook `hook_culturefeed_search_api_query_alter` allowing other modules to alter the query before it is executed.

We use this in Hasselt to limit all queries to the reg-hasselt region.