### PR TITLE
Pager support

### DIFF
--- a/modules/culturefeed_content/culturefeed_content.module
+++ b/modules/culturefeed_content/culturefeed_content.module
@@ -17,6 +17,7 @@ function culturefeed_content_theme() {
       'view_mode' => NULL,
       'title' => NULL,
       'more_link' => NULL,
+      'pager' => NULL,
     ],
     'file' => 'includes/theme.inc',
   ];

--- a/modules/culturefeed_content/src/Plugin/Field/FieldFormatter/CultureFeedContentDefaultFormatter.php
+++ b/modules/culturefeed_content/src/Plugin/Field/FieldFormatter/CultureFeedContentDefaultFormatter.php
@@ -77,6 +77,7 @@ class CultureFeedContentDefaultFormatter extends FormatterBase implements Contai
   public static function defaultSettings() {
     return [
       'view_mode' => 'teaser',
+      'pager' => FALSE,
     ] + parent::defaultSettings();
   }
 
@@ -93,6 +94,13 @@ class CultureFeedContentDefaultFormatter extends FormatterBase implements Contai
       '#description' => $this->t('Enter the desired output view mode for the search items'),
     ];
 
+    $form['pager'] = [
+      '#title' => $this->t('Show pager'),
+      '#type' => 'checkbox',
+      '#default_value' => $this->getSetting('pager'),
+      '#description' => $this->t('Check if a pager should be displayed below the results.'),
+    ];
+
     return $form;
   }
 
@@ -100,7 +108,10 @@ class CultureFeedContentDefaultFormatter extends FormatterBase implements Contai
    * {@inheritdoc}
    */
   public function settingsSummary() {
-    return ['#markup' => $this->t('View mode: %view_mode', ['%view_mode' => $this->getSetting('view_mode')])];
+    $summary = [];
+    $summary[] = $this->t('View mode: %view_mode', ['%view_mode' => $this->getSetting('view_mode')]);
+    $summary[] = $this->t('Pager: %pager', ['%pager' => $this->getSetting('pager') ? $this->t('Displayed') : $this->t('Hidden')]);
+    return $summary;
   }
 
   /**
@@ -122,6 +133,7 @@ class CultureFeedContentDefaultFormatter extends FormatterBase implements Contai
             $item->get('sort_direction')->getValue() ?? 'desc',
             $item->get('show_more_link')->getValue() ?? TRUE,
             $item->get('more_link')->getValue() ?? '',
+            $this->getSetting('pager'),
           ],
         ],
         '#create_placeholder' => TRUE,

--- a/modules/culturefeed_content/templates/culturefeed-content-formatter.html.twig
+++ b/modules/culturefeed_content/templates/culturefeed-content-formatter.html.twig
@@ -24,6 +24,7 @@
     {% endfor %}
   </div>
 {% endif %}
+{{ pager }}
 {% if more_link %}
 <div>
     {{ more_link }}


### PR DESCRIPTION
This will add support for pagers to the field formatter and the lazy builder in the culturefeed_content module. A new field formatter settings pager is being added that is disabled by default to stay backwards compatible with existing implementations.