### PR TITLE
Transform the Event ValueObject to a CalendarSummaryV3 Offer

### DIFF
--- a/modules/culturefeed_agenda/src/Utility/SearchPreprocessor.php
+++ b/modules/culturefeed_agenda/src/Utility/SearchPreprocessor.php
@@ -448,8 +448,8 @@ class SearchPreprocessor {
       // Temporary set to the default 'Available' till we have a solution to
       // fetch this from the valueObject.
       new BookingAvailability('Available'),
-      DateTimeImmutable::createFromMutable($event->getStartDate()),
-      DateTimeImmutable::createFromMutable($event->getEndDate()),
+      !empty($event->getStartDate()) ? DateTimeImmutable::createFromMutable($event->getStartDate()) : NULL,
+      !empty($event->getEndDate()) ? DateTimeImmutable::createFromMutable($event->getEndDate()) : NULL,
       new CalendarType($event->getCalendarType()),
     );
 

--- a/modules/culturefeed_agenda/src/Utility/SearchPreprocessor.php
+++ b/modules/culturefeed_agenda/src/Utility/SearchPreprocessor.php
@@ -441,7 +441,10 @@ class SearchPreprocessor {
   protected function eventToOffer(Event $event): Offer {
     $offer = new Offer(
       OfferType::event(),
-      new Status($event->getStatus()->getType(), $event->getStatus()->getReason()->getValues()),
+      new Status(
+        $event->getStatus()->getType(),
+        !empty($event->getStatus()->getReason()) ? $event->getStatus()->getReason()->getValues() : []
+      ),
       // Temporary set to the default 'Available' till we have a solution to
       // fetch this from the valueObject.
       new BookingAvailability('Available'),

--- a/modules/culturefeed_agenda/src/Utility/SearchPreprocessor.php
+++ b/modules/culturefeed_agenda/src/Utility/SearchPreprocessor.php
@@ -3,8 +3,14 @@
 namespace Drupal\culturefeed_agenda\Utility;
 
 use CultuurNet\CalendarSummaryV3\CalendarHTMLFormatter;
+use CultuurNet\CalendarSummaryV3\Offer\BookingAvailability;
+use CultuurNet\CalendarSummaryV3\Offer\CalendarType;
+use CultuurNet\CalendarSummaryV3\Offer\Offer;
+use CultuurNet\CalendarSummaryV3\Offer\OfferType;
+use CultuurNet\CalendarSummaryV3\Offer\Status;
 use CultuurNet\SearchV3\ValueObjects\Event;
 use CultuurNet\SearchV3\ValueObjects\Place;
+use DateTimeImmutable;
 use IntlDateFormatter;
 use Purl\Url;
 
@@ -314,7 +320,7 @@ class SearchPreprocessor {
 
     $formatter = new CalendarHTMLFormatter($locale);
 
-    return $formatter->format($event, 'md');
+    return $formatter->format($this->eventToOffer($event), 'md');
   }
 
   /**
@@ -340,7 +346,7 @@ class SearchPreprocessor {
 
     $formatter = new CalendarHTMLFormatter($locale);
 
-    return $formatter->format($event, 'lg');
+    return $formatter->format($this->eventToOffer($event), 'lg');
   }
 
   /**
@@ -421,6 +427,32 @@ class SearchPreprocessor {
     }
 
     return FALSE;
+  }
+
+  /**
+   * Transform an Event to an Offer to allow formatting of the Event.
+   *
+   * @param \CultuurNet\SearchV3\ValueObjects\Event $event
+   *   The Event.
+   *
+   * @return Offer
+   *   The Offer.
+   */
+  protected function eventToOffer(Event $event): Offer {
+    $offer = new Offer(
+      OfferType::event(),
+      new Status($event->getStatus()->getType(), $event->getStatus()->getReason()->getValues()),
+      // Temporary set to the default 'Available' till we have a solution to
+      // fetch this from the valueObject.
+      new BookingAvailability('Available'),
+      DateTimeImmutable::createFromMutable($event->getStartDate()),
+      DateTimeImmutable::createFromMutable($event->getEndDate()),
+      new CalendarType($event->getCalendarType()),
+    );
+
+    // @todo: Add the properties 'withSubEvents' and 'withOpeningHours'.
+
+    return $offer;
   }
 
 }


### PR DESCRIPTION
When you use the culturefeed_agenda sub-module the site will give an error:

```
The website encountered an unexpected error. Please try again later.
TypeError: Argument 1 passed to CultuurNet\CalendarSummaryV3\CalendarHTMLFormatter::format() must be an instance of CultuurNet\CalendarSummaryV3\Offer\Offer, instance of CultuurNet\SearchV3\ValueObjects\Event given, called in /web/modules/contrib/culturefeed-d8/modules/culturefeed_agenda/src/Utility/SearchPreprocessor.php on line 317 in CultuurNet\CalendarSummaryV3\CalendarHTMLFormatter->format() (line 83 of vendor/cultuurnet/calendar-summary-v3/src/CalendarHTMLFormatter.php).
```

This is a starting point to fix the error but needs work on adding 2 extra properties "withSubEvents and "withOpeningHours".