### PR TITLE
Fix AgendaSearchPagerBlock constructor

### DIFF
--- a/modules/culturefeed_agenda/src/Plugin/Block/AgendaSearchPagerBlock.php
+++ b/modules/culturefeed_agenda/src/Plugin/Block/AgendaSearchPagerBlock.php
@@ -3,6 +3,9 @@
 namespace Drupal\culturefeed_agenda\Plugin\Block;
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Pager\PagerManagerInterface;
+use Drupal\culturefeed_search\SearchPageServiceInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -35,8 +38,35 @@ class AgendaSearchPagerBlock extends AgendaSearchPageBlockBase {
       $configuration,
       $plugin_id,
       $plugin_definition,
+      $container->get('culturefeed_agenda.search_page_service'),
+      $container->get('form_builder'),
       $container->get('pager.manager')
     );
+  }
+
+  /**
+   * AgendaSearchPagerBlock constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\culturefeed_search\SearchPageServiceInterface $searchPageService
+   *   The search page service.
+   * @param \Drupal\Core\Form\FormBuilderInterface $formBuilder
+   *   The form builder.
+   * @param \Drupal\Core\Pager\PagerManagerInterface $pager_manager
+   *   The pager manager service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, SearchPageServiceInterface $searchPageService, FormBuilderInterface $formBuilder, PagerManagerInterface $pager_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $searchPageService, $formBuilder);
+
+    $this->pagerManager = $pager_manager;
   }
 
   /**


### PR DESCRIPTION
When going to the /agenda/zoeken page, you'll receive the next error:

`TypeError: Argument 4 passed to Drupal\culturefeed_agenda\Plugin\Block\AgendaSearchPageBlockBase::__construct() must implement interface Drupal\culturefeed_search\SearchPageServiceInterface, instance of Drupal\Core\Pager\PagerManager given, called in /web/modules/contrib/culturefeed-d8/modules/culturefeed_agenda/src/Plugin/Block/AgendaSearchPagerBlock.php on line 38 in Drupal\culturefeed_agenda\Plugin\Block\AgendaSearchPageBlockBase->__construct() (line 61 of modules/contrib/culturefeed-d8/modules/culturefeed_agenda/src/Plugin/Block/AgendaSearchPageBlockBase.php).`