### PR TITLE
Find a better solution for the admin links

### DIFF
--- a/modules/culturefeed_search/culturefeed_search.links.menu.yml
+++ b/modules/culturefeed_search/culturefeed_search.links.menu.yml
@@ -1,5 +1,0 @@
-culturefeed_search.settings:
-  route_name: culturefeed_search.settings
-  parent: system.admin_config
-  description: 'Administer the CultureFeed search settings.'
-  title: 'CultureFeed search settings'

--- a/modules/culturefeed_search/culturefeed_search.permissions.yml
+++ b/modules/culturefeed_search/culturefeed_search.permissions.yml
@@ -1,3 +1,0 @@
-administer culturefeed search configuration:
-  title: 'Administer Culturefeed search configuration'
-  description: 'Allows a user access to the Culturefeed search configuration pages'

--- a/modules/culturefeed_search/culturefeed_search.routing.yml
+++ b/modules/culturefeed_search/culturefeed_search.routing.yml
@@ -1,13 +1,3 @@
-culturefeed_search.settings:
-  path: '/admin/config/culturefeed-search'
-  defaults:
-    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
-    _title: 'Culturefeed search configuration'
-  requirements:
-    _permission: 'administer culturefeed search configuration'
-  options:
-    _admin_route: TRUE
-
 culturefeed_search.regions_autocomplete:
   path: '/culturfeed-search/regions-autocomplete'
   defaults:

--- a/modules/culturefeed_search_api/culturefeed_search_api.links.menu.yml
+++ b/modules/culturefeed_search_api/culturefeed_search_api.links.menu.yml
@@ -1,3 +1,9 @@
+culturefeed_search.settings:
+  route_name: culturefeed_search.settings
+  parent: system.admin_config
+  description: 'Administer the CultureFeed search settings.'
+  title: 'CultureFeed search settings'
+
 culturefeed_search_api.settings:
   title: 'Search API settings'
   description: 'Manage the search API settings.'

--- a/modules/culturefeed_search_api/culturefeed_search_api.permissions.yml
+++ b/modules/culturefeed_search_api/culturefeed_search_api.permissions.yml
@@ -1,3 +1,7 @@
+administer culturefeed search configuration:
+  title: 'Administer Culturefeed search configuration'
+  description: 'Allows a user access to the Culturefeed search configuration pages'
+
 administer search api configuration:
   title: 'Administer search API configuration'
   description: 'Allows a user to configure settings related with the search API'

--- a/modules/culturefeed_search_api/culturefeed_search_api.routing.yml
+++ b/modules/culturefeed_search_api/culturefeed_search_api.routing.yml
@@ -1,3 +1,13 @@
+culturefeed_search.settings:
+  path: '/admin/config/culturefeed-search'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Culturefeed search configuration'
+  requirements:
+    _permission: 'administer culturefeed search configuration'
+  options:
+    _admin_route: TRUE
+
 culturefeed_search_api.settings:
   path: '/admin/config/culturefeed-search/search-api'
   defaults:


### PR DESCRIPTION
When not having the culturefeed_search module enabled, the other modules config pages depending on the menu link and route are not visible anymore in the admin UI.

For now I just moved the link to the culturefeed_search_api module. But I think we should globally review the links provided by all the modules and replace them so the admin UI is more clear and everything is grouped.